### PR TITLE
NFC Reader support

### DIFF
--- a/ourspace-firmware/Makefile
+++ b/ourspace-firmware/Makefile
@@ -59,10 +59,9 @@ protobreaking: ../buf.lock bin/protoc-gen-buf-breaking ## Compares your current 
 
 generate: ## Generates code from protobuf files
 generate: bin/protoc-gen-grpc-gateway bin/protoc-gen-openapi ../buf.lock bin/protoc-gen-go bin/protoc-gen-go-grpc bin/protoc-gen-validate
-	PATH=$(PWD)/bin:$$PATH buf generate
 	PATH=$(PWD)/bin:$$PATH go generate ./...
 
-out/base.tar.gz: deployment/base.yaml deployment/overlay/etc/systemd/system/cage@.service out/firmware
+out/base.tar.gz: deployment/base.yaml $(shell find ./deployment/overlay -type f)
 	docker run \
 		-v $(PWD):/work \
 		-v /dev/kvm:/dev/kvm \
@@ -73,11 +72,24 @@ out/base.tar.gz: deployment/base.yaml deployment/overlay/etc/systemd/system/cage
 		--workdir /work \
 		godebos/debos \
 		--scratchsize=16G \
-		/work/deployment/base.yaml \
+		/work/deployment/base.yaml
+
+out/app.tar.gz: deployment/app.yaml out/firmware out/base.tar.gz
+	docker run \
+		-v $(PWD):/work \
+		-v /dev/kvm:/dev/kvm \
+		--privileged \
+		--cgroupns host \
+		--security-opt label=disable \
+		--cap-add=SYS_ADMIN \
+		--workdir /work \
+		godebos/debos \
+		--scratchsize=16G \
+		/work/deployment/app.yaml \
 		--template-var "backend_address:$(BACKEND_ADDRESS)" \
 		--template-var "api_key:$(API_KEY)"
 
-out/image.img: deployment/image.yaml out/base.tar.gz
+out/image.img: deployment/image.yaml out/app.tar.gz
 	docker run \
 		-v $(PWD):/work \
 		-v /dev/kvm:/dev/kvm \
@@ -90,6 +102,6 @@ out/image.img: deployment/image.yaml out/base.tar.gz
 		/work/deployment/image.yaml
 	sudo chown $(USER):$(GID) out/image.img
 
-.PHONY: out/firmware
+
 out/firmware:
 	go build -ldflags="-w -s" -o "$(@)" ./cmd/ourspace-firmware

--- a/ourspace-firmware/deployment/app.yaml
+++ b/ourspace-firmware/deployment/app.yaml
@@ -1,0 +1,22 @@
+architecture: amd64
+
+actions:
+  - action: unpack
+    file: out/base.tar.gz
+    compression: gz
+
+  - action: run
+    chroot: true
+    command: |
+      mkdir -p /opt/ourspace
+      echo "BACKEND_ADDRESS={{ .backend_address }}" >> /opt/ourspace/environment
+      echo "API_KEY={{ .api_key }}" >> /opt/ourspace/environment
+      echo "BACKEND_TLS=true" >> /opt/ourspace/environment
+
+  - action: overlay
+    source: ../out/firmware
+    destination: /opt/ourspace/firmware
+
+  - action: pack
+    file: out/app.tar.gz
+    compression: gz

--- a/ourspace-firmware/deployment/base.yaml
+++ b/ourspace-firmware/deployment/base.yaml
@@ -1,4 +1,4 @@
-{{- $mirror := or .mirror "http://deb.debian.org/debian" -}}
+{{- $mirror := or .mirror "https://ftp-stud.hs-esslingen.de/debian/" -}}
 {{- $suite := or .suite "trixie" -}}
 {{- $image := or .image "out/base.tar.gz" -}}
 
@@ -36,6 +36,7 @@ actions:
       - systemd
       - systemd-sysv
       - util-linux
+      - wlr-randr
       - zstd
 
   - action: overlay
@@ -44,7 +45,7 @@ actions:
   - action: run
     chroot: true
     command: |
-      echo "our-space-appliance" > /etc/hostname
+      echo "our-space-terminal" > /etc/hostname
       useradd \
         --uid 1000 \
         --user-group \
@@ -56,13 +57,6 @@ actions:
       systemctl enable ourspace.service
       mkdir -p /home/ourspace/.ssh/
       echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHDrMwsslvec7TeUJkrpnj6/04HsxDclgew5gPB61F24" >> /home/ourspace/.ssh/authorized_keys
-      mkdir -p /opt/ourspace
-      echo "BACKEND_ADDRESS={{ .backend_address }}" >> /opt/ourspace/environment
-      echo "API_KEY={{ .api_key }}" >> /opt/ourspace/environment
-
-  - action: overlay
-    source: ../out/firmware
-    destination: /opt/ourspace/firmware
 
   - action: pack
     file: {{ $image }}

--- a/ourspace-firmware/deployment/image.yaml
+++ b/ourspace-firmware/deployment/image.yaml
@@ -5,7 +5,7 @@ architecture: amd64
 
 actions:
   - action: unpack
-    file: out/base.tar.gz
+    file: out/app.tar.gz
     compression: gz
 
   - action: image-partition

--- a/ourspace-firmware/deployment/overlay/etc/default/grub
+++ b/ourspace-firmware/deployment/overlay/etc/default/grub
@@ -1,0 +1,5 @@
+GRUB_DEFAULT=0
+GRUB_TIMEOUT=5
+GRUB_DISTRIBUTOR=`( . /etc/os-release && echo ${NAME} )`
+GRUB_CMDLINE_LINUX_DEFAULT="quiet video=Virtual-1:1920x1080@60,rotate=90"
+GRUB_CMDLINE_LINUX=""

--- a/ourspace-firmware/deployment/overlay/etc/systemd/system/cage@.service
+++ b/ourspace-firmware/deployment/overlay/etc/systemd/system/cage@.service
@@ -23,7 +23,7 @@ After=getty@%i.service
 [Service]
 Type=simple
 ExecStart=/usr/bin/cage -- /usr/bin/chromium --no-sandbox --no-first-run --password-store=basic --simulate-outdated-no-au='Tue, 31 Dec 2199 23:59:59 GMT' --noerrdialogs --disable-infobars --kiosk --app='http://localhost:8080/terminal'
-#ExecStartPost=+sh -c "tty_name='%i'; exec chvt $${tty_name#tty}"
+ExecStartPost=/usr/bin/wlr-randr --output DP-1 --transform 90
 Restart=always
 User=ourspace
 # Log this user with utmp, letting it show up with commands 'w' and

--- a/ourspace-firmware/internal/firmware/notifier.go
+++ b/ourspace-firmware/internal/firmware/notifier.go
@@ -4,30 +4,31 @@ import (
 	"sync"
 )
 
-type Notifier struct {
+type Notifier[T any] struct {
 	cond  *sync.Cond
-	value []byte
+	value *T
 }
 
-func NewNotifier() *Notifier {
-	return &Notifier{
+func NewNotifier[T any]() *Notifier[T] {
+	return &Notifier[T]{
 		cond: sync.NewCond(&sync.Mutex{}),
 	}
 }
 
-func (n *Notifier) Notify(value []byte) {
+func (n *Notifier[T]) Notify(value *T) {
+	v := *value
+
 	n.cond.L.Lock()
-	n.value = value
+	n.value = &v
 	n.cond.Broadcast()
 	n.cond.L.Unlock()
 }
 
-func (n *Notifier) Wait() []byte {
+func (n *Notifier[T]) Wait() *T {
 	n.cond.L.Lock()
 	n.cond.Wait()
-	v := make([]byte, len(n.value))
-	copy(v, n.value)
+	v := *n.value
 	n.cond.L.Unlock()
 
-	return v
+	return &v
 }

--- a/ourspace-firmware/proto/api.openapi.yaml
+++ b/ourspace-firmware/proto/api.openapi.yaml
@@ -47,12 +47,13 @@ components:
         ScanCardRequest:
             type: object
             properties:
-                rfid_value:
+                card_serial:
                     type: string
-                    format: bytes
         ScanCardResponse:
             type: object
-            properties: {}
+            properties:
+                outcome:
+                    type: string
         Status:
             type: object
             properties:

--- a/ourspace-firmware/proto/api.pb.go
+++ b/ourspace-firmware/proto/api.pb.go
@@ -26,7 +26,7 @@ const (
 
 type ScanCardRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	RfidValue     []byte                 `protobuf:"bytes,1,opt,name=rfid_value,proto3" json:"rfid_value,omitempty"`
+	CardSerial    string                 `protobuf:"bytes,1,opt,name=card_serial,proto3" json:"card_serial,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -61,15 +61,16 @@ func (*ScanCardRequest) Descriptor() ([]byte, []int) {
 	return file_ourspace_firmware_proto_api_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *ScanCardRequest) GetRfidValue() []byte {
+func (x *ScanCardRequest) GetCardSerial() string {
 	if x != nil {
-		return x.RfidValue
+		return x.CardSerial
 	}
-	return nil
+	return ""
 }
 
 type ScanCardResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Outcome       string                 `protobuf:"bytes,1,opt,name=outcome,proto3" json:"outcome,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -102,6 +103,13 @@ func (x *ScanCardResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ScanCardResponse.ProtoReflect.Descriptor instead.
 func (*ScanCardResponse) Descriptor() ([]byte, []int) {
 	return file_ourspace_firmware_proto_api_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *ScanCardResponse) GetOutcome() string {
+	if x != nil {
+		return x.Outcome
+	}
+	return ""
 }
 
 type ListenForCardEventsRequest struct {
@@ -316,12 +324,11 @@ var File_ourspace_firmware_proto_api_proto protoreflect.FileDescriptor
 
 const file_ourspace_firmware_proto_api_proto_rawDesc = "" +
 	"\n" +
-	"!ourspace-firmware/proto/api.proto\x12\x14ourspace_firmware.v1\x1a$gnostic/openapi/v3/annotations.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"1\n" +
-	"\x0fScanCardRequest\x12\x1e\n" +
-	"\n" +
-	"rfid_value\x18\x01 \x01(\fR\n" +
-	"rfid_value\"\x12\n" +
-	"\x10ScanCardResponse\"\x1c\n" +
+	"!ourspace-firmware/proto/api.proto\x12\x14ourspace_firmware.v1\x1a$gnostic/openapi/v3/annotations.proto\x1a\x1cgoogle/api/annotations.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"3\n" +
+	"\x0fScanCardRequest\x12 \n" +
+	"\vcard_serial\x18\x01 \x01(\tR\vcard_serial\",\n" +
+	"\x10ScanCardResponse\x12\x18\n" +
+	"\aoutcome\x18\x01 \x01(\tR\aoutcome\"\x1c\n" +
 	"\x1aListenForCardEventsRequest\"\x99\x01\n" +
 	"\x1bListenForCardEventsResponse\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x12.\n" +

--- a/ourspace-firmware/proto/api.pb.validate.go
+++ b/ourspace-firmware/proto/api.pb.validate.go
@@ -57,7 +57,7 @@ func (m *ScanCardRequest) validate(all bool) error {
 
 	var errors []error
 
-	// no validation rules for RfidValue
+	// no validation rules for CardSerial
 
 	if len(errors) > 0 {
 		return ScanCardRequestMultiError(errors)
@@ -158,6 +158,8 @@ func (m *ScanCardResponse) validate(all bool) error {
 	}
 
 	var errors []error
+
+	// no validation rules for Outcome
 
 	if len(errors) > 0 {
 		return ScanCardResponseMultiError(errors)

--- a/ourspace-firmware/proto/api.proto
+++ b/ourspace-firmware/proto/api.proto
@@ -32,11 +32,11 @@ service FirmwareService {
 }
 
 message ScanCardRequest {
-  bytes rfid_value = 1 [json_name="rfid_value"];
+  string card_serial = 1 [json_name="card_serial"];
 }
 
 message ScanCardResponse {
-
+  string outcome = 1;
 }
 
 message ListenForCardEventsRequest {

--- a/ourspace-frontend/src/auth/token.ts
+++ b/ourspace-frontend/src/auth/token.ts
@@ -43,7 +43,7 @@ const processToken = (token: string) => {
   if (parts.length != 3) {
     return;
   }
-  const claims = JSON.parse(atob(parts[1]));
+  const claims = JSON.parse(base64Decode(parts[1]));
 
   userStoreRef.fullName = claims["full_name"];
 }
@@ -110,4 +110,10 @@ export const logout = async () => {
     body: {},
   });
   await router.push({name: "login"})
+}
+
+function base64Decode(str: string): string {
+  return decodeURIComponent(atob(str).split('').map(function(c) {
+    return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+  }).join(''));
 }


### PR DESCRIPTION
- Change API endpoint to accept hex encoded card serials 
- Move card and user lookup into the scan endpoint and respond with string codes that the reader interprets 
- Make Notifier generic
- Split firmware building into base and app steps to enable caching 
- Rotate screen after cage startup
- Fix frontend token decoding not using UTF-8