### PR TITLE
Member attributes: Manage via frontend

### DIFF
--- a/ourspace-backend/internal/members/repo.go
+++ b/ourspace-backend/internal/members/repo.go
@@ -650,7 +650,7 @@ func (p *Postgres) UpdateMemberAttribute(
 	}
 
 	_, err := p.db.ExecContext(ctx, `
-		update members_attributes
+		update member_attributes
 		set
 			display_name = coalesce($1, display_name),
 			description = coalesce($2, description)

--- a/ourspace-backend/proto/api.openapi.yaml
+++ b/ourspace-backend/proto/api.openapi.yaml
@@ -1378,6 +1378,12 @@ components:
                     additionalProperties:
                         type: string
         MemberAttribute:
+            required:
+                - id
+                - technical_name
+                - display_name
+                - type
+                - description
             type: object
             properties:
                 id:

--- a/ourspace-backend/proto/api.pb.go
+++ b/ourspace-backend/proto/api.pb.go
@@ -3757,7 +3757,7 @@ const file_ourspace_backend_proto_api_proto_rawDesc = "" +
 	"\n" +
 	"field_mask\x18\x02 \x01(\v2\x1a.google.protobuf.FieldMaskR\tfieldMask\".\n" +
 	"\x1cDeleteMemberAttributeRequest\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\"\xdc\x02\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\"\x9b\x03\n" +
 	"\x0fMemberAttribute\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12+\n" +
 	"\x0etechnical_name\x18\x02 \x01(\tB\x03\xe0A\x05R\x0etechnical_name\x12\"\n" +
@@ -3770,7 +3770,7 @@ const file_ourspace_backend_proto_api_proto_rawDesc = "" +
 	"\x13TYPE_TEXT_MULI_LINE\x10\x02\x12\x0f\n" +
 	"\vTYPE_NUMBER\x10\x03\x12\r\n" +
 	"\tTYPE_DATE\x10\x04\x12\x11\n" +
-	"\rTYPE_DATETIME\x10\x05\"\xdd\x01\n" +
+	"\rTYPE_DATETIME\x10\x05:=\xbaG:\xba\x01\x02id\xba\x01\x0etechnical_name\xba\x01\fdisplay_name\xba\x01\x04type\xba\x01\vdescription\"\xdd\x01\n" +
 	"\x18MemberAttributePageToken\x12B\n" +
 	"\x05field\x18\x01 \x01(\x0e2,.ourspace_backend.proto.MemberAttributeFieldR\x05field\x12\x1e\n" +
 	"\n" +

--- a/ourspace-backend/proto/api.proto
+++ b/ourspace-backend/proto/api.proto
@@ -286,6 +286,14 @@ message DeleteMemberAttributeRequest {
   string id = 1;
 }
 message MemberAttribute {
+  option (gnostic.openapi.v3.schema) = {
+    required: "id",
+    required: "technical_name",
+    required: "display_name",
+    required: "type",
+    required: "description",
+  };
+
   string id = 1;
   string technical_name = 2 [json_name="technical_name", (google.api.field_behavior)=IMMUTABLE];
   string display_name = 3 [json_name="display_name"];

--- a/ourspace-frontend/src/App.vue
+++ b/ourspace-frontend/src/App.vue
@@ -32,6 +32,7 @@ const user = userStore()
       <OnyxNavBar app-name="OurSpace" v-if="route.meta.navbar ?? true">
         <OnyxNavItem label="Members" link="/members"></OnyxNavItem>
         <OnyxNavItem label="Cards" link="/cards"></OnyxNavItem>
+        <OnyxNavItem label="Settings" link="/settings"></OnyxNavItem>
         <template #contextArea>
           <OnyxUserMenu v-if="loggedIn" :full-name="user.fullName">
             <OnyxColorSchemeMenuItem v-model="colorScheme" />

--- a/ourspace-frontend/src/client/types.gen.ts
+++ b/ourspace-frontend/src/client/types.gen.ts
@@ -157,11 +157,11 @@ export type MemberWritable = {
 };
 
 export type MemberAttribute = {
-    id?: string;
-    technical_name?: string;
-    display_name?: string;
-    type?: 'TYPE_UNKNOWN' | 'TYPE_TEXT_SINGLE_LINE' | 'TYPE_TEXT_MULI_LINE' | 'TYPE_NUMBER' | 'TYPE_DATE' | 'TYPE_DATETIME';
-    description?: string;
+    id: string;
+    technical_name: string;
+    display_name: string;
+    type: 'TYPE_UNKNOWN' | 'TYPE_TEXT_SINGLE_LINE' | 'TYPE_TEXT_MULI_LINE' | 'TYPE_NUMBER' | 'TYPE_DATE' | 'TYPE_DATETIME';
+    description: string;
 };
 
 export type MemberLoginReadable = {

--- a/ourspace-frontend/src/router.ts
+++ b/ourspace-frontend/src/router.ts
@@ -6,6 +6,7 @@ import CardsView from '@/views/cards/CardsView.vue'
 import CardEditView from '@/views/cards/CardEditView.vue'
 import TerminalView from '@/views/terminal/TerminalView.vue'
 import LoginView from '@/views/login/LoginView.vue'
+import SettingsView from "@/views/settings/SettingsView.vue";
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -64,6 +65,11 @@ const router = createRouter({
         authenticated: false,
       },
     },
+    {
+      path: '/settings',
+      name: 'settings',
+      component: SettingsView,
+    }
   ],
 })
 

--- a/ourspace-frontend/src/views/settings/SettingsView.vue
+++ b/ourspace-frontend/src/views/settings/SettingsView.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+
+import {OnyxPageLayout} from "sit-onyx";
+import MemberAttributes from "@/views/settings/components/MemberAttributes.vue";
+</script>
+
+<template>
+  <OnyxPageLayout>
+    <h1 class="headline">Settings</h1>
+    <div class="settings-section">
+      <MemberAttributes/>
+    </div>
+  </OnyxPageLayout>
+</template>
+
+<style scoped>
+.settings-section {
+  margin-top: var(--onyx-density-lg);
+  margin-bottom: var(--onyx-density-lg);
+}
+</style>

--- a/ourspace-frontend/src/views/settings/components/MemberAttributeActions.vue
+++ b/ourspace-frontend/src/views/settings/components/MemberAttributeActions.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import {OnyxIconButton} from "sit-onyx";
+import editIcon from "@sit-onyx/icons/edit.svg?raw";
+import deleteIcon from "@sit-onyx/icons/trash.svg?raw";
+
+defineEmits(['edit', 'delete']);
+</script>
+
+<template>
+  <div>
+    <OnyxIconButton label="Edit" :icon="editIcon" color="neutral" density="compact" @click="$emit('edit')" />
+    <OnyxIconButton label="Delete" :icon="deleteIcon" color="neutral" density="compact" @click="$emit('delete')" />
+  </div>
+</template>
+
+<style scoped>
+
+</style>

--- a/ourspace-frontend/src/views/settings/components/MemberAttributes.vue
+++ b/ourspace-frontend/src/views/settings/components/MemberAttributes.vue
@@ -1,0 +1,422 @@
+<script setup lang="ts">
+import {
+  type ColumnConfig,
+  type ColumnTypesFromFeatures,
+  createFeature,
+  DataGridFeatures,
+  OnyxBottomBar,
+  OnyxButton,
+  OnyxDataGrid,
+  OnyxForm,
+  OnyxIconButton,
+  OnyxInput,
+  OnyxModal,
+  OnyxSelect,
+  OnyxTextarea,
+} from "sit-onyx";
+import {computed, h, ref, watch} from "vue";
+import MemberAttributeActions from "@/views/settings/components/MemberAttributeActions.vue";
+import {
+  type MemberAttribute,
+  memberServiceCreateMemberAttribute,
+  memberServiceDeleteMemberAttribute,
+  memberServiceListMemberAttributes,
+  type MemberServiceListMemberAttributesResponse,
+  memberServiceUpdateMemberAttribute
+} from "@/client";
+import {
+  iconChevronFirstPage,
+  iconChevronRightSmall,
+  iconPlusSmall,
+  iconSync
+} from "@sit-onyx/icons";
+
+type MemberAttributeEntry = {
+  id: string,
+  technicalName: string,
+  displayName: string,
+  type: string,
+  description: string,
+};
+
+const reload = ref(0);
+const response = ref<MemberServiceListMemberAttributesResponse>();
+const currentPageToken = ref<string>('');
+
+const nextPage = () => {
+  if (response.value?.next_page_token) {
+    currentPageToken.value = response.value.next_page_token;
+  }
+};
+
+const shouldShowNextPage = computed(
+  (): boolean => response.value?.next_page_token !== undefined && response.value.next_page_token !== ''
+);
+
+const firstPage = () => {
+  currentPageToken.value = '';
+}
+const isFirstPage = computed(() => currentPageToken.value === '');
+
+const withCustomType = createFeature(() => ({
+  name: Symbol('member attribute row actions'),
+  typeRenderer: {
+    actions: DataGridFeatures.createTypeRenderer<object, MemberAttributeEntry>({
+      cell: {
+        tdAttributes: {
+          style: {width: 'calc(4rem + 2*var(--onyx-density-md))'},
+        },
+        component: ({modelValue, row}) => {
+          const id = modelValue?.toString() ?? ''
+          return h(MemberAttributeActions, {
+            id: id,
+            onEdit: () => {
+              createEditModal.value.mode = 'edit';
+              createEditModal.value.value = {
+                id: row.id,
+                display_name: row.displayName,
+                technical_name: row.technicalName,
+                description: row.description,
+                type: row.type as (MemberAttribute['type']),
+              };
+              createEditModal.value.original = {
+                ...createEditModal.value.value,
+              }
+              createEditModal.value.id = row.id;
+              createEditModal.value.open = true;
+            },
+            onDelete: () => {
+              deleteModal.value.id = row.id;
+              deleteModal.value.entry = row;
+              deleteModal.value.open = true;
+            },
+          })
+        },
+      },
+    }),
+    attributeType: DataGridFeatures.createTypeRenderer<object, MemberAttributeEntry>({
+      cell: {
+        component: ({modelValue}) => {
+          switch (modelValue) {
+            case 'TYPE_TEXT_SINGLE_LINE':
+              return 'Single line text';
+            case 'TYPE_TEXT_MULI_LINE':
+              return 'Multi line text'
+            case 'TYPE_NUMBER':
+              return 'Numerical text';
+            case 'TYPE_DATE':
+              return 'Date';
+            case 'TYPE_DATETIME':
+              return 'Date and time';
+          }
+        },
+      },
+    }),
+  },
+}));
+
+const withCustomActions = createFeature(() => ({
+  name: Symbol('member attribute actions'),
+  actions: () => [
+    {
+      label: "Reload",
+      icon: iconSync,
+      color: "neutral",
+      onClick: () => reload.value++,
+    },
+    {
+      label: "Add attribute",
+      icon: iconPlusSmall,
+      displayAs: "button",
+      mode: "plain",
+      group: "group-1",
+      onClick: () => {
+        createEditModal.value.mode = 'create';
+        createEditModal.value.value = {
+          id: '',
+          technical_name: '',
+          display_name: '',
+          description: '',
+          type: 'TYPE_UNKNOWN',
+        }
+        createEditModal.value.open = true;
+      },
+    }
+  ],
+}))
+
+const features = [withCustomType, withCustomActions];
+
+const columns: ColumnConfig<
+  MemberAttributeEntry,
+  Record<string, never>,
+  ColumnTypesFromFeatures<typeof features>
+>[] = [
+  {key: 'technicalName', label: 'Technical Name'},
+  {key: 'displayName', label: 'Display Name'},
+  {key: 'type', label: 'Data Type', type: 'attributeType'},
+  {key: 'description', label: 'Description'},
+  {key: 'id', label: 'Actions', type: 'actions', width: 'min-content'},
+];
+
+const data = computed(() => {
+  return (
+    response.value?.attributes?.map((attribute): MemberAttributeEntry => ({
+        id: attribute.id,
+        technicalName: attribute.technical_name,
+        displayName: attribute.display_name,
+        type: attribute.type,
+        description: attribute.description,
+      }),
+    ) ?? [])
+});
+
+watch([currentPageToken, reload], async () => {
+  const resp = await memberServiceListMemberAttributes({
+    query: {
+      page_size: 5,
+      sort_by: "MEMBER_ATTRIBUTE_FIELD_TECHNICAL_NAME",
+      sort_direction: "SORT_DIRECTION_ASCENDING",
+      page_token: currentPageToken.value,
+    }
+  });
+
+  if (resp.error) {
+    console.error(resp.error);
+  } else {
+    response.value = resp.data;
+  }
+}, {immediate: true});
+
+const createEditModal = ref<{
+  open: boolean;
+  mode?: 'create' | 'edit';
+  id?: string;
+  value: MemberAttribute;
+  original?: MemberAttribute;
+}>({
+  open: false,
+  value: {
+    id: '',
+    technical_name: '',
+    display_name: '',
+    description: '',
+    type: 'TYPE_UNKNOWN',
+  }
+});
+
+const handleSubmit = async () => {
+  switch (createEditModal.value.mode) {
+    case 'create':
+      await createAttribute(createEditModal.value.value);
+      break;
+    case 'edit':
+      if (createEditModal.value.id === undefined || createEditModal.value.original === undefined) {
+        return;
+      }
+
+      await patchAttribute(createEditModal.value.id, createEditModal.value.value, createEditModal.value.original ?? {});
+      break;
+  }
+
+  createEditModal.value.open = false
+  reload.value++;
+};
+
+const createAttribute = async (value: MemberAttribute) => {
+  return memberServiceCreateMemberAttribute({
+    body: value,
+  });
+};
+
+const patchAttribute = async (id: string, value: MemberAttribute, original: MemberAttribute) => {
+  const fieldMask: string[] = [];
+
+  if (value.display_name !== original.display_name) {
+    fieldMask.push('display_name');
+  }
+
+  if (value.description !== original.description) {
+    fieldMask.push('description');
+  }
+
+  return memberServiceUpdateMemberAttribute({
+    body: value,
+    path: {
+      "attribute.id": id,
+    },
+    query: {
+      field_mask: fieldMask.join(','),
+    },
+  })
+};
+
+const attributeTypeOptions: {
+  value: MemberAttribute['type'],
+  label: string,
+}[] = [
+  {
+    value: 'TYPE_TEXT_SINGLE_LINE',
+    label: 'Single line text'
+  },
+  {
+    value: 'TYPE_TEXT_MULI_LINE',
+    label: 'Multi line text'
+  },
+  {
+    value: 'TYPE_NUMBER',
+    label: 'Numerical text'
+  },
+  {
+    value: 'TYPE_DATE',
+    label: 'Date value'
+  },
+  {
+    value: 'TYPE_DATETIME',
+    label: 'Date and time'
+  }
+];
+
+const deleteModal = ref<{
+  open: boolean;
+  id?: string;
+  entry?: MemberAttributeEntry;
+}>({
+  open: false,
+});
+
+const handleDelete = async () => {
+  if (deleteModal.value.id === undefined) {
+    return;
+  }
+
+  const resp = await memberServiceDeleteMemberAttribute({
+    path: {
+      id: deleteModal.value.id,
+    }
+  });
+
+  if (resp.error) {
+    console.error(resp.error);
+  }
+
+  deleteModal.value.open = false;
+  reload.value++;
+}
+</script>
+
+<template>
+  <h2 class="headline">Custom attributes</h2>
+  <p class="info-text">
+    Custom attributes allow you to extend the member data model with attributes that suit your
+    needs.
+  </p>
+  <OnyxDataGrid headline="Attributes" :columns="columns" :data :features
+                class="onyx-density-compact"/>
+  <div class="table-bottom-actions">
+    <OnyxIconButton
+      :icon="iconChevronFirstPage"
+      label="Back to start"
+      density="compact"
+      :disabled="isFirstPage"
+      @click="firstPage"
+      color="neutral"
+    />
+    <OnyxIconButton
+      :icon="iconChevronRightSmall"
+      label="Next Page"
+      density="compact"
+      :disabled="!shouldShowNextPage"
+      @click="nextPage"
+      color="neutral"
+    />
+  </div>
+  <OnyxModal :label="createEditModal.mode === 'create' ? 'Create Attribute' : 'Edit Attribute'"
+             :open="createEditModal.open"
+             @update:open="createEditModal.open = false"
+             :nonDismissible="true"
+  >
+    <template #default>
+      <div class="edit-modal">
+        <OnyxForm @submit.prevent="handleSubmit">
+          <OnyxInput label="Technical Name"
+                     v-model="createEditModal.value.technical_name"
+                     required
+                     :readonly="createEditModal.mode === 'edit'"
+          />
+          <OnyxInput label="Display Name"
+                     v-model="createEditModal.value.display_name"
+                     required
+                     :maxlength="256"
+                     withCounter
+          />
+          <OnyxSelect label="Type"
+                      listLabel="Attribute data types"
+                      :options="attributeTypeOptions"
+                      v-model="createEditModal.value.type"
+                      required
+                      :readonly="createEditModal.mode === 'edit'"
+          />
+          <OnyxTextarea label="Description"
+                        v-model="createEditModal.value.description"
+                        required
+                        :maxlenght="4096"
+                        withCounter
+          />
+        </OnyxForm>
+      </div>
+    </template>
+    <template #footer>
+      <OnyxBottomBar>
+        <OnyxButton label="Cancel" color="neutral" mode="plain"
+                    @click="createEditModal.open = false"/>
+        <OnyxButton label="Save" color="primary" mode="plain"
+                    @click="handleSubmit"/>
+      </OnyxBottomBar>
+    </template>
+  </OnyxModal>
+  <OnyxModal :open="deleteModal.open" label="Delete Attribute">
+    <template #default>
+      <div class="delete-modal">
+        <p>Do you really want to delete the attribute "{{ deleteModal.entry?.technicalName }}"?</p>
+        <p>
+          This will not delete the attribute values on all members. Instead they will be listed
+          as an unknown attribute value and the attribute can't be added to any new members.
+        </p>
+      </div>
+    </template>
+    <template #footer>
+      <OnyxBottomBar>
+        <OnyxButton label="Cancel" color="neutral" mode="plain" @click="deleteModal.open = false" />
+        <OnyxButton label="Delete" color="danger" mode="plain" @click="handleDelete()" />
+      </OnyxBottomBar>
+    </template>
+  </OnyxModal>
+</template>
+
+<style scoped>
+.headline {
+  margin-bottom: var(--onyx-density-xs);
+}
+
+.info-text {
+  color: var(--onyx-color-text-icons-neutral-medium);
+}
+
+.table-bottom-actions {
+  margin-top: 8px;
+  display: flex;
+  flex-direction: row;
+  justify-content: end;
+  gap: var(--onyx-density-xs);
+}
+
+.edit-modal {
+  padding: var(--onyx-density-xl) var(--onyx-modal-padding-inline);
+  width: calc(100vw - 2 * var(--onyx-grid-margin));
+}
+
+.delete-modal {
+  padding: var(--onyx-density-xl) var(--onyx-modal-padding-inline);
+}
+</style>

--- a/ourspace-frontend/src/views/settings/components/MemberAttributes.vue
+++ b/ourspace-frontend/src/views/settings/components/MemberAttributes.vue
@@ -39,7 +39,6 @@ type MemberAttributeEntry = {
   description: string,
 };
 
-const reload = ref(0);
 const response = ref<MemberServiceListMemberAttributesResponse>();
 const currentPageToken = ref<string>('');
 
@@ -122,7 +121,7 @@ const withCustomActions = createFeature(() => ({
       label: "Reload",
       icon: iconSync,
       color: "neutral",
-      onClick: () => reload.value++,
+      onClick: () => loadPage(currentPageToken.value),
     },
     {
       label: "Add attribute",
@@ -171,13 +170,13 @@ const data = computed(() => {
     ) ?? [])
 });
 
-watch([currentPageToken, reload], async () => {
+const loadPage = async (pageToken: string): Promise<void> => {
   const resp = await memberServiceListMemberAttributes({
     query: {
       page_size: 5,
       sort_by: "MEMBER_ATTRIBUTE_FIELD_TECHNICAL_NAME",
       sort_direction: "SORT_DIRECTION_ASCENDING",
-      page_token: currentPageToken.value,
+      page_token: pageToken,
     }
   });
 
@@ -186,6 +185,11 @@ watch([currentPageToken, reload], async () => {
   } else {
     response.value = resp.data;
   }
+}
+
+watch([currentPageToken], async () => {
+  await loadPage(currentPageToken.value)
+
 }, {immediate: true});
 
 const createEditModal = ref<{
@@ -220,7 +224,7 @@ const handleSubmit = async () => {
   }
 
   createEditModal.value.open = false
-  reload.value++;
+  await loadPage(currentPageToken.value);
 };
 
 const createAttribute = async (value: MemberAttribute) => {
@@ -301,7 +305,7 @@ const handleDelete = async () => {
   }
 
   deleteModal.value.open = false;
-  reload.value++;
+  await loadPage(currentPageToken.value);
 }
 </script>
 
@@ -333,8 +337,7 @@ const handleDelete = async () => {
   </div>
   <OnyxModal :label="createEditModal.mode === 'create' ? 'Create Attribute' : 'Edit Attribute'"
              :open="createEditModal.open"
-             @update:open="createEditModal.open = false"
-             :nonDismissible="true"
+             nonDismissible
   >
     <template #default>
       <div class="edit-modal">
@@ -360,7 +363,7 @@ const handleDelete = async () => {
           <OnyxTextarea label="Description"
                         v-model="createEditModal.value.description"
                         required
-                        :maxlenght="4096"
+                        :maxlength="4096"
                         withCounter
           />
         </OnyxForm>


### PR DESCRIPTION
Make member attribute fields required in protobuf/openapi Fix typo in table name of UpdateMemberAttributes
Add settings page, add it to router and navigation Add member attribute configuration section, support CRUD and pagination on the table.

Error cases are currently just handled by printing to the console, we'll need to add some unified handling to all places.